### PR TITLE
Automatically dark/light screenshot in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,11 @@ python3 src/main.py
 
 <details>
     <summary><h2>Screenshots</h2></summary>
-    
-![Alt text](/screenshots/full-light-1.png?raw=true "App with two columns in light theme")
-![Alt text](/screenshots/full-dark-1.png?raw=true "App with two columns in dark theme")
-![Alt text](/screenshots/mobile-light-1.png?raw=true "App with one column (mobile view) in dark theme")
+
+<picture>
+  <source srcset="/screenshots/full-dark-1.png?raw=true" media="(prefers-color-scheme: dark)">
+  <img src="/screenshots/full-light-1.png?raw=true" title="App with two columns" alt="screenshot-desktop">
+</picture>
+
+![screenshot-mobile](/screenshots/mobile-light-1.png?raw=true "App with one column (mobile view)")
 </details>


### PR DESCRIPTION
Users who are using dark mode probably don't wanna see a light mode screenshot and vice versa. This PR makes it so that people using dark mode are presented with the dark mode screenshot only and the people using light mode are presented with the light mode screenshot only.

This only applies to the two column screenshot since the mobile view screenshot does not currently have a dark version in the repo.