### PR TITLE
Correct imports

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,11 @@
 #!/usr/bin/python
 
 
-from gi.repository import Gtk, Adw, GLib
 import gi
+gi.require_version('Gtk', '4.0')
+gi.require_version('Adw', '1')
+from gi.repository import Gtk, Adw, GLib
+
 import subprocess
 import json
 import os
@@ -14,11 +17,7 @@ from widgets.vault_types.login import Login
 from widgets.vault_types.credit_card import CreditCard
 from widgets.vault_types.id import Id
 
-
 from dotenv import load_dotenv
-
-gi.require_version('Gtk', '4.0')
-gi.require_version('Adw', '1')
 load_dotenv()
 
 


### PR DESCRIPTION
Fixes the following:

```
PyGIWarning: Gtk was imported without specifying a version first. Use gi.require_version('Gtk', '4.0') before import to ensure that the right version gets loaded.
  from gi.repository import Gtk, Adw, GLib
PyGIWarning: Adw was imported without specifying a version first. Use gi.require_version('Adw', '1') before import to ensure that the right version gets loaded.
  from gi.repository import Gtk, Adw, GLib
```